### PR TITLE
Remove social media icons added in by addthis

### DIFF
--- a/web/app/themes/imb/base.php
+++ b/web/app/themes/imb/base.php
@@ -24,8 +24,5 @@
 
 	<?php get_footer(); ?>
 
-  <!-- Go to www.addthis.com/dashboard to customize your tools -->
-  <script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-55d49ccb5d8a5bba" async="async"></script>
-
 </body>
 </html>


### PR DESCRIPTION
Addthis add in additional cookies, which are non-essential. We're trialling a new cookie banner on the IMB site, and this would complicate that banner. So we're removing this for now, whilst we run that test.