### PR TITLE
Override flex-box with patch to align vacancies page cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ web/app/mu-plugins/wp-*/*
 web/app/plugins/*
 web/app/upgrade
 web/app/uploads/*
+web/app/uploads
 
 !web/app/mu-plugins/.gitkeep
 !web/app/plugins/.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,13 @@ default: build
 build:
 	bin/build.sh
 
+# Run the project upgrade script
+update:
+	bin/upgrade.sh
+
+upgrade:
+	bin/upgrade.sh
+
 # Remove ignored git files – e.g. composer dependencies and built theme assets
 # But keep .idea directory (PhpStorm config), and uploaded media files
 clean:
@@ -21,6 +28,10 @@ run:
 # Run the application
 down:
 	docker-compose down
+
+# Launch the application, open browser, no stdout
+launch:
+	bin/launch.sh
 
 # Launch the application, open browser, no stdout
 run-launch:

--- a/bin/upgrade.sh
+++ b/bin/upgrade.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+###
+# Build Script
+# Use this script to upgrade theme assets.
+##
+
+# Install PHP dependencies (WordPress, plugins, etc.)
+composer upgrade
+
+if ! [ -x "$(command -v npm-upgrade)" ]; then
+  echo 'The command npm-upgrade is required to upgrade node packages. Install this and try again.'
+  echo 'npm i -g npm-upgrade'
+  exit 1
+fi
+
+# Build theme assets
+# Supports multiple themes
+for d in web/app/themes/*; do
+  if [[ -f "$d/package.json" ]]; then
+    echo "***"
+    echo "Upgrading dependancies in $d/package.json"
+    echo "***"
+    cd "$d"
+    npm-upgrade
+    npm install
+    npm audit fix
+    cd ../../../..
+  fi
+done
+
+# Remove composer auth.json
+rm -f auth.json

--- a/composer.lock
+++ b/composer.lock
@@ -8,11 +8,11 @@
     "packages": [
         {
             "name": "acf/advanced-custom-fields-pro",
-            "version": "5.8.11",
+            "version": "5.8.12",
             "dist": {
                 "type": "zip",
-                "url": "https://composer.wp.dsd.io/dist/acf/advanced-custom-fields-pro/acf-advanced-custom-fields-pro-5.8.11.zip",
-                "shasum": "d3d3254dfc1ff42f01645f21b82baa158cc99796"
+                "url": "https://composer.wp.dsd.io/dist/acf/advanced-custom-fields-pro/acf-advanced-custom-fields-pro-5.8.12.zip",
+                "shasum": "165d5168a76cc8b54be4a8ba3b003bdfdec6119d"
             },
             "type": "wordpress-plugin"
         },
@@ -581,16 +581,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.17.1",
+            "version": "v1.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d"
+                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d",
-                "reference": "2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1c302646f6efc070cd46856e600e5e0684d6b454",
+                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454",
                 "shasum": ""
             },
             "require": {
@@ -602,7 +602,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17-dev"
+                    "dev-master": "1.18-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -639,25 +639,25 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2020-06-06T08:46:27+00:00"
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v2.6.5",
+            "version": "v2.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "2e977311ffb17b2f82028a9c36824647789c6365"
+                "reference": "e1d57f62db3db00d9139078cbedf262280701479"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/2e977311ffb17b2f82028a9c36824647789c6365",
-                "reference": "2e977311ffb17b2f82028a9c36824647789c6365",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/e1d57f62db3db00d9139078cbedf262280701479",
+                "reference": "e1d57f62db3db00d9139078cbedf262280701479",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.9 || ^7.0 || ^8.0",
-                "symfony/polyfill-ctype": "^1.16"
+                "symfony/polyfill-ctype": "^1.17"
             },
             "require-dev": {
                 "ext-filter": "*",
@@ -701,19 +701,19 @@
                 "env",
                 "environment"
             ],
-            "time": "2020-06-02T14:06:52+00:00"
+            "time": "2020-07-14T17:54:18+00:00"
         },
         {
             "name": "wpackagist-plugin/analytify-analytics-dashboard-widget",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/analytify-analytics-dashboard-widget/",
-                "reference": "tags/1.1.3"
+                "reference": "tags/1.1.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/analytify-analytics-dashboard-widget.1.1.3.zip"
+                "url": "https://downloads.wordpress.org/plugin/analytify-analytics-dashboard-widget.1.1.4.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -813,15 +813,15 @@
         },
         {
             "name": "wpackagist-plugin/wordpress-seo",
-            "version": "14.4.1",
+            "version": "14.6.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wordpress-seo/",
-                "reference": "tags/14.4.1"
+                "reference": "tags/14.6.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.14.4.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.14.6.1.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -831,15 +831,15 @@
         },
         {
             "name": "wpackagist-plugin/wp-analytify",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wp-analytify/",
-                "reference": "tags/3.0.0"
+                "reference": "tags/3.1.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-analytify.3.0.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/wp-analytify.3.1.0.zip"
             },
             "require": {
                 "composer/installers": "~1.0"

--- a/web/app/themes/imb/assets/css/patch.css
+++ b/web/app/themes/imb/assets/css/patch.css
@@ -119,6 +119,6 @@ h4.sort-by {
 	}
 
 	.card-group > .card {
-		flex: 1 0 100%;
+		flex: 1 0 100% !important;
 	}
 }

--- a/web/app/themes/imb/assets/mix-manifest.json
+++ b/web/app/themes/imb/assets/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/js/jquery.js": "/js/jquery.js?id=377896f4d232004cb8c0",
-    "/js/scripts.min.js": "/js/scripts.min.js?id=b919ada855616a320b40",
-    "/css/main.min.css": "/css/main.min.css?id=2bc547e6dcf3ddc3f665"
+    "/js/jquery.js": "/js/jquery.js",
+    "/js/scripts.min.js": "/js/scripts.min.js",
+    "/css/main.min.css": "/css/main.min.css"
 }

--- a/web/app/themes/imb/package-lock.json
+++ b/web/app/themes/imb/package-lock.json
@@ -984,6 +984,12 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/json-schema": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
+			"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
+			"dev": true
+		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -2520,17 +2526,6 @@
 						"strip-ansi": "^5.0.0"
 					}
 				}
-			}
-		},
-		"clone-deep": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-			"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-			"dev": true,
-			"requires": {
-				"is-plain-object": "^2.0.4",
-				"kind-of": "^6.0.2",
-				"shallow-clone": "^3.0.0"
 			}
 		},
 		"coa": {
@@ -6344,6 +6339,12 @@
 			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
 			"dev": true
 		},
+		"klona": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/klona/-/klona-1.1.2.tgz",
+			"integrity": "sha512-xf88rTeHiXk+XE2Vhi6yj8Wm3gMZrygGdKjJqN8HkV+PwF/t50/LdAKHoHpPcxFAlmQszTZ1CugrK25S7qDRLA==",
+			"dev": true
+		},
 		"laravel-mix": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/laravel-mix/-/laravel-mix-5.0.4.tgz",
@@ -6605,9 +6606,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"version": "4.17.19",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
 			"dev": true
 		},
 		"lodash.memoize": {
@@ -9465,22 +9466,56 @@
 			}
 		},
 		"sass-loader": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
-			"integrity": "sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-9.0.2.tgz",
+			"integrity": "sha512-nphcum3jNI442njnrZ5wJgSNX5lfEOHOKHCLf+PrTIaleploKqAMUuT9CVKjf+lyi6c2MCGPHh1vb9nGsjnZJA==",
 			"dev": true,
 			"requires": {
-				"clone-deep": "^4.0.1",
-				"loader-utils": "^1.2.3",
+				"klona": "^1.1.1",
+				"loader-utils": "^2.0.0",
 				"neo-async": "^2.6.1",
-				"schema-utils": "^2.6.1",
-				"semver": "^6.3.0"
+				"schema-utils": "^2.7.0",
+				"semver": "^7.3.2"
 			},
 			"dependencies": {
+				"ajv": {
+					"version": "6.12.3",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+					"integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"loader-utils": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+					"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^2.1.2"
+					}
+				},
+				"schema-utils": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+					"integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+					"dev": true,
+					"requires": {
+						"@types/json-schema": "^7.0.4",
+						"ajv": "^6.12.2",
+						"ajv-keywords": "^3.4.1"
+					}
+				},
 				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
 					"dev": true
 				}
 			}
@@ -9717,15 +9752,6 @@
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
-			}
-		},
-		"shallow-clone": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-			"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-			"dev": true,
-			"requires": {
-				"kind-of": "^6.0.2"
 			}
 		},
 		"shebang-command": {

--- a/web/app/themes/imb/package.json
+++ b/web/app/themes/imb/package.json
@@ -30,15 +30,15 @@
 		"bootstrap": "^4.5.0",
 		"jquery": "^3.5.1",
 		"npm-modernizr": "^2.8.3",
-		"popper.js": "^1.15.0",
+		"popper.js": "^1.16.1",
 		"scrollpoints": "^0.4.0"
 	},
 	"devDependencies": {
 		"laravel-mix": "^5.0.4",
 		"node-sass": "^4.14.1",
 		"resolve-url-loader": "^3.1.1",
-		"sass": "^1.26.8",
-		"sass-loader": "^8.0.2",
+		"sass": "^1.26.10",
+		"sass-loader": "^9.0.2",
 		"vue-template-compiler": "^2.6.11"
 	}
 }


### PR DESCRIPTION
Fix bug: https://trello.com/c/zxNZpaNr/1021-imb-issues-with-ie11
- Added !important to _media queried_ selector that targets the vacancy listing only
- Updated dependancies
- Included our upgrade.sh script for easier software upgrades

In the css there is a flex override in patch.css that fixes a layout issue. In IE11 this override is ignored. Applying !important (a sledgehammer) in a targeted way applies the fix. Have tested in chrome and IE11 including responsive display.

Nb. during this work I noticed is a wider issue with mobile responsiveness. The problem is the site doesn't fit in the window correctly or size properly when resized. Due to the ALB Refresh I haven't attempted to fix it. I hope that is ok. :o)